### PR TITLE
Update DatepickerLite.vue

### DIFF
--- a/src/components/DatepickerLite.vue
+++ b/src/components/DatepickerLite.vue
@@ -288,7 +288,7 @@ export default defineComponent({
         let startDateWeekday = startDate.getDay();
         let lastDateWeekday = lastDate.getDay();
         let startsWeeks =
-          props.locale.startsWeeks < 0 || props.locale.startsWeeks > 6
+          props.locale.startsWeeks < 0 || props.locale.startsWeeks > 6 || !props.locale.startsWeek
             ? 0
             : props.locale.startsWeeks;
         if (startDateWeekday != startsWeeks) {


### PR DESCRIPTION
The calendar stopped working when no startWeeks property was provided.