### PR TITLE
Added option to disable browser input autocomplete

### DIFF
--- a/src/components/DatepickerLite.vue
+++ b/src/components/DatepickerLite.vue
@@ -5,6 +5,7 @@
       :id="idAttr"
       :name="nameAttr"
       :class="classAttr"
+      :autocomplete="autocompleteAttr"
       :placeholder="placeholderAttr"
       v-model="selectedValue"
       @focus="datepicker.show = true"
@@ -112,6 +113,10 @@ export default defineComponent({
     placeholderAttr: {
       type: String,
       default: "",
+    },
+    autocompleteAttr: {
+      type: String,
+      default: "off",
     },
     yearMinus: {
       type: Number,


### PR DESCRIPTION
I've added the option to disable the browser's autocomplete. This makes sure that the browser does not longer suggests formerly used values in the input which show up in front of the calendar popup.